### PR TITLE
FIXED: typo "github"

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ from  plugins.pagure import  get_pull_requests
 
 
 @click.command()
-@click.option('--site', default='config', help='Please enter the sitename to list activity, e.g. gitgub')
+@click.option('--site', default='config', help='Please enter the sitename to list activity, e.g. github')
 @click.option('--username', default='config', help='Please enter username to list activity, e.g. HariSadu')
 @click.option('--repo', default='config', help='Please enter repository name to list activity, e.g. helloworld')
 def execute_board(site,  username, repo):


### PR DESCRIPTION
Renamed "gitgub" with "github"